### PR TITLE
Return job_id from execute() and execute_complete() method in SubmitAnyscaleJob

### DIFF
--- a/tests/operators/test_anyscale_operators.py
+++ b/tests/operators/test_anyscale_operators.py
@@ -51,7 +51,7 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
     def test_execute_complete(self, mock_hook):
         event = {"state": JobState.SUCCEEDED, "job_id": "123", "message": "Job completed successfully"}
-        self.assertEqual(self.operator.execute_complete(Context(), event), None)
+        self.assertEqual(self.operator.execute_complete(Context(), event), "123")
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
     def test_execute_complete_failure(self, mock_hook):


### PR DESCRIPTION
Per customer feedback, they would like to use the job_id in downstream tasks for tracking. 

This PR returns the job_id from both the execute() and the execute_complete() methods. We also updated the associated unit test


![image](https://github.com/user-attachments/assets/ea52d391-a8d0-4900-a3df-7e9b49821158)

