### PR TITLE
Fix running unittests locally when `ANYSCALE_CLI_TOKEN` is set

### DIFF
--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest import mock
 from unittest.mock import patch
 
@@ -33,6 +34,7 @@ class TestAnyscaleHook:
                 )
                 self.hook = AnyscaleHook()
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("anyscale_provider.hooks.anyscale.AnyscaleHook.get_connection")
     def test_api_key_required(self, mock_get_connection):
         mock_get_connection.return_value = Connection(


### PR DESCRIPTION
If the environment variable was set and we attempted to run:
```
hatch run tests.py3.8-2.9:test-cov
```

We'd face the error:
```
========================================================== FAILURES ==========================================================
___________________________________________ TestAnyscaleHook.test_api_key_required ___________________________________________

self = <tests.hooks.test_anyscale_hook.TestAnyscaleHook object at 0x107b678e0>
mock_get_connection = <MagicMock name='get_connection' id='4435544336'>

    @patch.dict(os.environ, {})
    @patch("anyscale_provider.hooks.anyscale.AnyscaleHook.get_connection")
    def test_api_key_required(self, mock_get_connection):
        mock_get_connection.return_value = Connection(
            conn_id="anyscale_default", conn_type="http", host="localhost", password=None, extra=json.dumps({})
        )
    
        with pytest.raises(AirflowException) as ctx:
>           AnyscaleHook().client
E           Failed: DID NOT RAISE <class 'airflow.exceptions.AirflowException'>

tests/hooks/test_anyscale_hook.py:45: Failed
```

This PR solves this.