### PR TITLE
Fix example DAG `sample_anyscale_service_workflow`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main", "fix-example-dag" ]
   pull_request:
-    branches: [ "main", "fix-example-dag" ]
+    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,9 +105,10 @@ jobs:
       - name: Test Anyscale against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
         run: |
           ID="${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}"
-          ID_CLEANED=$(echo $ID | tr '.' '-')  # Replace dots with hyphens
-          echo "ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED" >> $GITHUB_ENV
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
+          # Service names must be no longer than 57 characters and can only contain alphanumeric characters, dashes, and underscores
+          ID_CLEANED=$(echo $ID | tr '.' '-')  # Replace dots with hyphens so it is a valid Service name
+          echo ASTRO_ANYSCALE_PROVIDER_SERVICE_ID
+          ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
         env:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
       - name: Upload coverage to Github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           ID="${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}"
           # Service names must be no longer than 57 characters and can only contain alphanumeric characters, dashes, and underscores
-          ID_CLEANED=$(echo $ID | tr '.' '-')  # Replace dots with hyphens so it is a valid Service name
+          ID_CLEANED=$(echo $ID | tr '.' '-' | tr '/' '-')  # Replace dots and forward slashes with hyphens so it is a valid Service name
           echo ASTRO_ANYSCALE_PROVIDER_SERVICE_ID
           ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [ "main", "fix-example-dag" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "fix-example-dag" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "fix-example-dag" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -113,6 +113,8 @@ jobs:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
           include-hidden-files: true
+    env:
+      ASTRO_ANYSCALE_PROVIDER_SERVICE_ID: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
   Code-Coverage:
     if: github.event.action != 'labeled'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           path: .coverage
           include-hidden-files: true
     env:
-      ASTRO_ANYSCALE_PROVIDER_SERVICE_ID: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      ASTRO_ANYSCALE_PROVIDER_SERVICE_ID: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}
 
   Code-Coverage:
     if: github.event.action != 'labeled'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,9 @@ jobs:
 
       - name: Test Anyscale against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
         run: |
+          ID="${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}"
+          ID_CLEANED=$(echo $ID | tr '.' '-')  # Replace dots with hyphens
+          echo "ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED" >> $GITHUB_ENV
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
         env:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
@@ -113,8 +116,6 @@ jobs:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
           include-hidden-files: true
-    env:
-      ASTRO_ANYSCALE_PROVIDER_SERVICE_ID: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}
 
   Code-Coverage:
     if: github.event.action != 'labeled'

--- a/example_dags/anyscale_service.py
+++ b/example_dags/anyscale_service.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import datetime, timedelta
 
@@ -20,7 +21,8 @@ default_args = {
 
 # Define the Anyscale connection
 ANYSCALE_CONN_ID = "anyscale_conn"
-SERVICE_NAME = f"AstroService-CICD-{uuid.uuid4()}"
+service_id = os.getenv("ASTRO_ANYSCALE_PROVIDER_SERVICE_ID", {uuid.uuid4()})
+SERVICE_NAME = f"AstroService-CICD-{service_id}"
 
 dag = DAG(
     "sample_anyscale_service_workflow",


### PR DESCRIPTION
The example DAG  `sample_anyscale_service_workflow` previously defined a UUID that was expected to be used in different tasks while maintaining the same value. This approach does not work in most setups of Airflow, especially in a distributed environment, since the DAG is reparsed at each executor, resulting in different UUIDs.

This is an example of what happened even when trying to run this DAG locally:
<img width="1189" alt="Screenshot 2025-03-20 at 14 56 55" src="https://github.com/user-attachments/assets/dca5fd21-c3cd-4296-8e39-36d17395b683" />

Where the second task mentions it cannot find the Anyscale service `AstroService-CICD-9220ff9a-ede3-47ee-a583-0f1bcd9581cc`.
```
  File "/Users/tati/Code/astro-provider-anyscale/dags/anyscale_service.py", line 52, in terminate_service
    result = hook.terminate_service(service_name=SERVICE_NAME, time_delay=5)
  File "/Users/tati/Code/astro-provider-anyscale/venv/lib/python3.9/site-packages/anyscale_provider/hooks/anyscale.py", line 141, in terminate_service
    raise AirflowException(f"Service termination failed with error: {e}")
airflow.exceptions.AirflowException: Service termination failed with error: Service with name 'AstroService-CICD-9220ff9a-ede3-47ee-a583-0f1bcd9581cc' was not found.
```

While the first task succeeds, mentioning it successfully created the service `AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297`, which has a different UUID.
```

[2025-03-20, 14:19:46 UTC] {taskinstance.py:289} INFO - Pausing task as DEFERRED. dag_id=sample_anyscale_service_workflow, task_id=rollout_anyscale_service, run_id=manual__2025-03-20T14:19:36.827994+00:00, execution_date=20250320T141936, start_date=20250320T141938
[2025-03-20, 14:19:46 UTC] {taskinstance.py:341} ▶ Post task execution logs
[2025-03-20, 14:19:48 UTC] {anyscale.py:174} INFO - Monitoring service AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 every 30 seconds to reach RUNNING
[2025-03-20, 14:19:48 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:19:48 UTC] {base.py:84} INFO - Retrieving connection 'anyscale_conn'
[2025-03-20, 14:19:48 UTC] {anyscale.py:36} INFO - Using Anyscale connection_id: anyscale_conn
[2025-03-20, 14:19:54 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:20:24 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:20:26 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:20:56 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:20:58 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:21:28 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:21:29 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:21:59 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:22:01 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:22:31 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:22:33 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:23:03 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:23:05 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:23:35 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:23:38 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: STARTING
[2025-03-20, 14:24:08 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:24:10 UTC] {anyscale.py:233} INFO - Current service state for AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297 is: RUNNING
[2025-03-20, 14:24:10 UTC] {anyscale.py:109} INFO - Fetching service status for Service: AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297
[2025-03-20, 14:24:12 UTC] {triggerer_job_runner.py:631} INFO - Trigger sample_anyscale_service_workflow/manual__2025-03-20T14:19:36.827994+00:00/rollout_anyscale_service/-1/1 (ID 1) fired: TriggerEvent<{'state': <ServiceState.RUNNING: 'RUNNING'>, 'message': 'Service deployment succeeded', 'service_name': 'AstroService-CICD-a3f7d907-318a-4cd8-98b4-a53340a78297'}>
```

This PR solves the issue by allowing users to specify a fixed ID that can be reused across multiple tasks of the same DAG.

After this fix, the DAG run successfully:
![Screenshot 2025-03-20 at 15 08 41](https://github.com/user-attachments/assets/67868cdc-5b28-499f-83a0-835cee32fed8)
