### PR TITLE
Fix integration test hanging in the CI

### DIFF
--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -5,6 +5,7 @@ import time
 from functools import cached_property
 from typing import Any
 
+import click
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -49,7 +50,11 @@ class AnyscaleHook(BaseHook):
         if telemetry_enabled:
             headers["X-Anyscale-Source"] = "airflow"
 
-        return Anyscale(auth_token=token, headers=headers)
+        try:
+            anyscale_client = Anyscale(auth_token=token, headers=headers)
+        except click.exceptions.ClickException:
+            raise AirflowException(f"Unable to access Anyscale using the connection {self.conn_id}")
+        return anyscale_client
 
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:

--- a/example_dags/anyscale_service.py
+++ b/example_dags/anyscale_service.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
@@ -14,8 +14,7 @@ default_args = {
     "start_date": datetime(2024, 4, 2),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 1,
-    "retry_delay": timedelta(minutes=5),
+    "retries": 0,
 }
 
 # Define the Anyscale connection


### PR DESCRIPTION
The CI was hanging in previous PRs indefinitely until Github timed it out.

Example:
https://github.com/astronomer/astro-provider-anyscale/actions/runs/13016320320/job/36306305057

```
DEBUG    airflow.models.dagrun.DagRun:dagrun.py:953 number of scheduleable tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
[2025-01-28T19:05:32.515+0000] {dag.py:2923} WARNING - No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_workflow.initialize_anyscale_hook manual__2025-01-28T17:42:51.609966+00:00 [None]>}
WARNING  airflow.models.dag.DAG:dag.py:2923 No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_workflow.initialize_anyscale_hook manual__2025-01-28T17:42:51.609966+00:00 [None]>}
[2025-01-28T19:05:33.519+0000] {dagrun.py:932} DEBUG - number of tis tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
DEBUG    airflow.models.dagrun.DagRun:dagrun.py:932 number of tis tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
[2025-01-28T19:05:33.519+0000] {dagrun.py:953} DEBUG - number of scheduleable tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
DEBUG    airflow.models.dagrun.DagRun:dagrun.py:953 number of scheduleable tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
[2025-01-28T19:05:33.526+0000] {dag.py:2923} WARNING - No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_workflow.initialize_anyscale_hook manual__2025-01-28T17:42:51.609966+00:00 [None]>}
WARNING  airflow.models.dag.DAG:dag.py:2923 No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_workflow.initialize_anyscale_hook manual__2025-01-28T17:42:51.609966+00:00 [None]>}
[2025-01-28T19:05:34.530+0000] {dagrun.py:932} DEBUG - number of tis tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
DEBUG    airflow.models.dagrun.DagRun:dagrun.py:932 number of tis tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
[2025-01-28T19:05:34.531+0000] {dagrun.py:953} DEBUG - number of scheduleable tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
DEBUG    airflow.models.dagrun.DagRun:dagrun.py:953 number of scheduleable tasks for <DagRun sample_anyscale_service_workflow @ 2025-01-28 17:42:51.609966+00:00: manual__2025-01-28T17:42:51.609966+00:00, state:running, queued_at: None. externally triggered: False>: 2 task(s)
[2025-01-28T19:05:34.536+0000] {dag.py:2923} WARNING - No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_workflow.initialize_anyscale_hook manual__2025-01-28T17:42:51.609966+00:00 [None]>}
WARNING  airflow.models.dag.DAG:dag.py:2923 No tasks to run. unrunnable tasks: {<TaskInstance: sample_anyscale_service_workflow.rollout_anyscale_service manual__2025-01-28T17:42:51.609966+00:00 [up_for_retry]>, <TaskInstance: sample_anyscale_service_
```

I was able to reproduce this locally by setting:
```
export ASTRO_ANYSCALE_PROVIDER_SERVICE_ID="tati-test"
```

This PR aims to make our CI fail faster and not hang if there are any issues with this example DAG. It also gives a more user friendly error explaining what's wrong.