### PR TITLE
Release 1.1.0 & introduce changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 1.1.0 (2025-03-31)
+
+Features
+
+* Add `target_job_queue` to `SubmitAnyscaleJob` operator by @RCdeWit in https://github.com/astronomer/astro-provider-anyscale/pull/52
+
+Improvements
+
+* Use an Airflow config to manage provider configuration by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/41
+
+Others
+
+* Upgrade GitHub action artifacts upload-artifact & download-artifact to v4 by @pankajkoti in https://github.com/astronomer/astro-provider-anyscale/pull/53
+* Add Dependabot configuration by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/54
+* Bump actions/checkout from 2 to 4 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/56
+* Bump codecov/codecov-action from 4 to 5 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/55
+* Bump actions/setup-python from 2 to 5 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/58
+* Bump pypa/gh-action-pypi-publish from 1.8.14 to 1.12.4 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/59
+* Fix running unittests locally when ANYSCALE_CLI_TOKEN is set by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/61
+* Fix example DAG sample_anyscale_service_workflow by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/62
+* Fix integration test hanging in the CI  by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/63
+* Fix broken tests by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/64

--- a/anyscale_provider/__init__.py
+++ b/anyscale_provider/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 from typing import Any
 


### PR DESCRIPTION
**Features**

* Add `target_job_queue` to `SubmitAnyscaleJob` operator by @RCdeWit in https://github.com/astronomer/astro-provider-anyscale/pull/52

**Improvements**

* Use an Airflow config to manage provider configuration by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/41

**Others**

* Upgrade GitHub action artifacts upload-artifact & download-artifact to v4 by @pankajkoti in https://github.com/astronomer/astro-provider-anyscale/pull/53
* Add Dependabot configuration by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/54
* Bump actions/checkout from 2 to 4 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/56
* Bump codecov/codecov-action from 4 to 5 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/55
* Bump actions/setup-python from 2 to 5 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/58
* Bump pypa/gh-action-pypi-publish from 1.8.14 to 1.12.4 by @dependabot in https://github.com/astronomer/astro-provider-anyscale/pull/59
* Fix running unittests locally when `ANYSCALE_CLI_TOKEN` is set by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/61
* Fix example DAG `sample_anyscale_service_workflow` by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/62
* Fix integration test hanging in the CI  by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/63
* Fix broken tests by @tatiana in https://github.com/astronomer/astro-provider-anyscale/pull/64
