### PR TITLE
Fix MyPy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
             attrs,
             types-requests,
             types-python-dateutil,
-            apache-airflow,
+            apache-airflow~=2.9,
           ]
         files: ^anyscale_provider
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,7 @@ repos:
             attrs,
             types-requests,
             types-python-dateutil,
+            # TODO: Revert this line once Airflow 3 is supported
             apache-airflow~=2.9,
           ]
         files: ^anyscale_provider


### PR DESCRIPTION
This PR brings our main branch back to green. This change will be reverted once we validate that the provider works with Airflow 3, in separate PRs.

The CI main branch has been failing while trying to run static checks using:
```
hatch run tests.py3.11-2.9:static-check
```

Example of output:
```
 mypy-python.......................................................................Failed
- hook id: mypy
- exit code: 1

anyscale_provider/hooks/anyscale.py:11: error: Module "airflow.hooks.base" has no attribute "BaseHook"  [attr-defined]
anyscale_provider/hooks/anyscale.py:17: error: Class cannot subclass "BaseHook" (has type "Any")  [misc]
anyscale_provider/triggers/anyscale.py:35: error: Untyped decorator makes function "hook" untyped  [misc]
anyscale_provider/triggers/anyscale.py:85: error: Call to untyped function "TriggerEvent" in typed context  [no-untyped-call]
anyscale_provider/triggers/anyscale.py:93: error: Call to untyped function "TriggerEvent" in typed context  [no-untyped-call]
anyscale_provider/triggers/anyscale.py:142: error: Untyped decorator makes function "hook" untyped  [misc]
anyscale_provider/triggers/anyscale.py:184: error: Call to untyped function "TriggerEvent" in typed context  [no-untyped-call]
anyscale_provider/triggers/anyscale.py:193: error: Call to untyped function "TriggerEvent" in typed context  [no-untyped-call]
anyscale_provider/triggers/anyscale.py:204: error: Call to untyped function "TriggerEvent" in typed context  [no-untyped-call]
anyscale_provider/operators/anyscale.py:10: error: Module "airflow.utils.context" does not explicitly export attribute "Context"  [attr-defined]
anyscale_provider/operators/anyscale.py:124: error: Untyped decorator makes function "hook" untyped  [misc]
anyscale_provider/operators/anyscale.py:178: error: Argument "job_id" to "AnyscaleJobTrigger" has incompatible type "str | None"; expected "str"  [arg-type]
anyscale_provider/operators/anyscale.py:187: error: Incompatible return value type (got "str | None", expected "str")  [return-value]
anyscale_provider/operators/anyscale.py:322: error: Untyped decorator makes function "hook" untyped  [misc]
Found 14 errors in 3 files (checked 7 source files)
```

Closes: https://github.com/astronomer/astro-provider-anyscale/issues/75