### PR TITLE
Fix `RolloutAnyscaleService` after Anyscale SDK breaking change

### DIFF
--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -110,7 +110,11 @@ class AnyscaleHook(BaseHook):
         try:
             # We assume this is the compatible with Anyscale SDK. It is with 0.26.75.
             service_id: str = self.client.service.deploy(
-                configs=configs, in_place=in_place, canary_percent=canary_percent, max_surge_percent=max_surge_percent
+                configs=configs,
+                in_place=in_place,
+                canary_percent=canary_percent,
+                max_surge_percent=max_surge_percent,
+                versions=None,
             )
         except TypeError:
             # The following used to work at some point when the provider used to be "anyscale>=0.24.54" and Anyscale SDK 0.26.75 hadn't been released yet,

--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -78,7 +78,7 @@ class AnyscaleHook(BaseHook):
     def deploy_service(
         self,
         config: ServiceConfig | None = None,
-        configs: list[ServiceConfig] | None = None,
+        configs: list[ServiceConfig] | ServiceConfig | None = None,
         in_place: bool = False,
         canary_percent: int | None = None,
         max_surge_percent: int | None = None,
@@ -86,8 +86,8 @@ class AnyscaleHook(BaseHook):
         """
         Deploy a service to Anyscale.
 
-        :param config: (deprecated in 1.2.0) Use configs instead. Configuration dictionary for the service.
-        :param configs: Required (introduced in 1.2.0). List of configuration dictionaries for the service.
+        :param config: (deprecated in 1.2.0) Use configs instead. Configuration object for the service.
+        :param configs: Required (introduced in 1.2.0). Maybe a list of configuration objects for the service, or a single configuration object.
         :param in_place: Optional. Whether to perform an in-place update. Defaults to False.
         :param canary_percent: Optional. Canary percentage for deployment.
         :param max_surge_percent: Optional. Maximum surge percentage for deployment.
@@ -103,18 +103,18 @@ class AnyscaleHook(BaseHook):
             self.log.warning(
                 "Specifying the config in the `config` argument is deprecated. Please use the `configs` argument instead."
             )
-            configs = [config]
+            configs = config
 
         self.log.info(f"Deploying a service with configuration: {configs}")
 
         try:
             # We assume this is the compatible with Anyscale SDK. It is with 0.26.75.
+            # self.client.service.deploy( configs=configs, in_place=in_place, canary_percent=canary_percent, max_surge_percent=max_surge_percent)
             service_id: str = self.client.service.deploy(
                 configs=configs,
                 in_place=in_place,
                 canary_percent=canary_percent,
                 max_surge_percent=max_surge_percent,
-                versions=None,
             )
         except TypeError:
             # The following used to work at some point when the provider used to be "anyscale>=0.24.54" and Anyscale SDK 0.26.75 hadn't been released yet,

--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -77,7 +77,7 @@ class AnyscaleHook(BaseHook):
 
     def deploy_service(
         self,
-        config: ServiceConfig,
+        configs: list[ServiceConfig],
         in_place: bool = False,
         canary_percent: int | None = None,
         max_surge_percent: int | None = None,
@@ -90,9 +90,9 @@ class AnyscaleHook(BaseHook):
         :param canary_percent: Optional. Canary percentage for deployment.
         :param max_surge_percent: Optional. Maximum surge percentage for deployment.
         """
-        self.log.info(f"Deploying a service with configuration: {config}")
+        self.log.info(f"Deploying a service with configuration: {configs}")
         service_id: str = self.client.service.deploy(
-            config=config, in_place=in_place, canary_percent=canary_percent, max_surge_percent=max_surge_percent
+            configs=configs, in_place=in_place, canary_percent=canary_percent, max_surge_percent=max_surge_percent
         )
         return service_id
 

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -378,7 +378,7 @@ class RolloutAnyscaleService(BaseOperator):
 
         # Call the SDK method with the dynamically created service model
         self.service_id = self.hook.deploy_service(
-            config=svc_config,
+            configs=[svc_config],
             in_place=self.in_place,
             canary_percent=self.canary_percent,
             max_surge_percent=self.max_surge_percent,

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -378,7 +378,7 @@ class RolloutAnyscaleService(BaseOperator):
 
         # Call the SDK method with the dynamically created service model
         self.service_id = self.hook.deploy_service(
-            configs=[svc_config],
+            configs=svc_config,
             in_place=self.in_place,
             canary_percent=self.canary_percent,
             max_surge_percent=self.max_surge_percent,

--- a/scripts/test/integration_test.sh
+++ b/scripts/test/integration_test.sh
@@ -1,8 +1,2 @@
 pytest -vv \
-    --cov=anyscale_provider \
-    --cov-report=term-missing \
-    --cov-report=xml \
-    --durations=0 \
-    -m integration \
-    -s \
-    --log-cli-level=DEBUG
+    tests/dags/test_dag_example.py::test_dag_runs[example_dags/anyscale_service.py]

--- a/scripts/test/integration_test.sh
+++ b/scripts/test/integration_test.sh
@@ -1,2 +1,8 @@
 pytest -vv \
-    tests/dags/test_dag_example.py::test_dag_runs[example_dags/anyscale_service.py]
+    --cov=anyscale_provider \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --durations=0 \
+    -m integration \
+    -s \
+    --log-cli-level=DEBUG

--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -132,7 +132,7 @@ class TestAnyscaleHook:
         )
 
         mock_client.service.deploy.assert_called_once_with(
-            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20, versions=None
+            configs=service_config, in_place=False, canary_percent=10, max_surge_percent=20
         )
         assert result == "test_service_id"
 
@@ -146,10 +146,10 @@ class TestAnyscaleHook:
         mock_client.service.deploy.side_effect = AirflowException("Deploy service failed")
 
         with pytest.raises(AirflowException) as exc:
-            self.hook.deploy_service(configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20)
+            self.hook.deploy_service(configs=service_config, in_place=False, canary_percent=10, max_surge_percent=20)
 
         mock_client.service.deploy.assert_called_once_with(
-            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20, versions=None
+            configs=service_config, in_place=False, canary_percent=10, max_surge_percent=20
         )
         assert str(exc.value) == "Deploy service failed"
 
@@ -366,7 +366,7 @@ class TestAnyscaleHook:
         # First call should use 'configs' (new SDK style)
         first_call_kwargs = mock_client.service.deploy.call_args_list[0][1]
         assert "configs" in first_call_kwargs
-        assert first_call_kwargs["configs"] == [service_config]
+        assert first_call_kwargs["configs"] == service_config
         assert first_call_kwargs["in_place"] is True
         assert first_call_kwargs["canary_percent"] == 5
         assert first_call_kwargs["max_surge_percent"] == 10

--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -127,7 +127,9 @@ class TestAnyscaleHook:
 
         mock_client.service.deploy.return_value = "test_service_id"
 
-        result = self.hook.deploy_service([service_config], in_place=False, canary_percent=10, max_surge_percent=20)
+        result = self.hook.deploy_service(
+            config=service_config, in_place=False, canary_percent=10, max_surge_percent=20
+        )
 
         mock_client.service.deploy.assert_called_once_with(
             configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20
@@ -144,7 +146,7 @@ class TestAnyscaleHook:
         mock_client.service.deploy.side_effect = AirflowException("Deploy service failed")
 
         with pytest.raises(AirflowException) as exc:
-            self.hook.deploy_service([service_config], in_place=False, canary_percent=10, max_surge_percent=20)
+            self.hook.deploy_service(configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20)
 
         mock_client.service.deploy.assert_called_once_with(
             configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20

--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -319,3 +319,64 @@ class TestAnyscaleHook:
             mock_terminate.assert_called_once_with(name="test_service")
             mock_sleep.assert_called_once_with(1)
             assert result is True
+
+    @patch("anyscale_provider.hooks.anyscale.AnyscaleHook.client")
+    def test_deploy_service_both_config_and_configs_provided(self, mock_client):
+        """Test that exception is raised when both config and configs are provided (line 97)"""
+        mock_client.return_value = mock_anyscale
+        service_config = ServiceConfig(
+            name="test_service", applications=[{"name": "app1", "import_path": "module.optional_submodule:app"}]
+        )
+
+        with pytest.raises(AirflowException) as exc:
+            self.hook.deploy_service(config=service_config, configs=[service_config])
+
+        assert str(exc.value) == "Only one of the arguments `config` or `configs` can be provided"
+
+    @patch("anyscale_provider.hooks.anyscale.AnyscaleHook.client")
+    def test_deploy_service_neither_config_nor_configs_provided(self, mock_client):
+        """Test that exception is raised when neither config nor configs are provided (line 99)"""
+        mock_client.return_value = mock_anyscale
+
+        with pytest.raises(AirflowException) as exc:
+            self.hook.deploy_service()
+
+        assert str(exc.value) == "Either `config` or `configs`argument must be provided"
+
+    @patch("anyscale_provider.hooks.anyscale.AnyscaleHook.client")
+    def test_deploy_service_fallback_to_old_sdk(self, mock_client):
+        """Test fallback to old SDK API when TypeError is raised (line 121-124)"""
+        mock_client.return_value = mock_anyscale
+        service_config = ServiceConfig(
+            name="test_service", applications=[{"name": "app1", "import_path": "module.optional_submodule:app"}]
+        )
+
+        # Make the first call raise TypeError (new SDK doesn't support 'configs')
+        # Then make the second call succeed with the old 'config' parameter
+        mock_client.service.deploy.side_effect = [
+            TypeError("ServiceSDK.deploy() got an unexpected keyword argument 'configs'"),
+            "test_service_id",
+        ]
+
+        result = self.hook.deploy_service(config=service_config, in_place=True, canary_percent=5, max_surge_percent=10)
+
+        # Check that deploy was called twice: first with configs, then with config
+        assert mock_client.service.deploy.call_count == 2
+
+        # First call should use 'configs' (new SDK style)
+        first_call_kwargs = mock_client.service.deploy.call_args_list[0][1]
+        assert "configs" in first_call_kwargs
+        assert first_call_kwargs["configs"] == [service_config]
+        assert first_call_kwargs["in_place"] is True
+        assert first_call_kwargs["canary_percent"] == 5
+        assert first_call_kwargs["max_surge_percent"] == 10
+
+        # Second call should use 'config' (old SDK style)
+        second_call_kwargs = mock_client.service.deploy.call_args_list[1][1]
+        assert "config" in second_call_kwargs
+        assert second_call_kwargs["config"] == service_config
+        assert second_call_kwargs["in_place"] is True
+        assert second_call_kwargs["canary_percent"] == 5
+        assert second_call_kwargs["max_surge_percent"] == 10
+
+        assert result == "test_service_id"

--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -132,7 +132,7 @@ class TestAnyscaleHook:
         )
 
         mock_client.service.deploy.assert_called_once_with(
-            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20
+            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20, versions=None
         )
         assert result == "test_service_id"
 
@@ -149,7 +149,7 @@ class TestAnyscaleHook:
             self.hook.deploy_service(configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20)
 
         mock_client.service.deploy.assert_called_once_with(
-            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20
+            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20, versions=None
         )
         assert str(exc.value) == "Deploy service failed"
 

--- a/tests/hooks/test_anyscale_hook.py
+++ b/tests/hooks/test_anyscale_hook.py
@@ -127,10 +127,10 @@ class TestAnyscaleHook:
 
         mock_client.service.deploy.return_value = "test_service_id"
 
-        result = self.hook.deploy_service(service_config, in_place=False, canary_percent=10, max_surge_percent=20)
+        result = self.hook.deploy_service([service_config], in_place=False, canary_percent=10, max_surge_percent=20)
 
         mock_client.service.deploy.assert_called_once_with(
-            config=service_config, in_place=False, canary_percent=10, max_surge_percent=20
+            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20
         )
         assert result == "test_service_id"
 
@@ -144,10 +144,10 @@ class TestAnyscaleHook:
         mock_client.service.deploy.side_effect = AirflowException("Deploy service failed")
 
         with pytest.raises(AirflowException) as exc:
-            self.hook.deploy_service(service_config, in_place=False, canary_percent=10, max_surge_percent=20)
+            self.hook.deploy_service([service_config], in_place=False, canary_percent=10, max_surge_percent=20)
 
         mock_client.service.deploy.assert_called_once_with(
-            config=service_config, in_place=False, canary_percent=10, max_surge_percent=20
+            configs=[service_config], in_place=False, canary_percent=10, max_surge_percent=20
         )
         assert str(exc.value) == "Deploy service failed"
 


### PR DESCRIPTION
The Anyscale Python SDK introduced a breaking change by removing support for the `Service` `config` argument and introducing the `configs` argument. I suspect this happened somewhere between versions 0.24.54 (the provider is pinned to this version or higher) and 0.26.75 (the last released version). However, since the tests were not running as expected, and there is no changelog for the Anyscale Python SDK, it is hard to pinpoint when the change happened.

The new interface is described in the official documentation: https://docs.anyscale.com/reference/service-api\#service-sdk
<img width="902" height="605" alt="Screenshot 2025-11-20 at 11 29 04" src="https://github.com/user-attachments/assets/e8033a02-223b-4884-acf8-50d5c56b29e4" />

This breaking change led to the `RolloutAnyscaleService` operator stopping working.

This issue was identified while working on https://github.com/astronomer/astro-provider-anyscale/pull/92, when I improved how the integration tests work, and I noticed that the example DAG `sample_anyscale_service_workflow` has been failing with the following error message:
```
  File "/Users/tatiana.alchueyr/Code/astro-provider-anyscale/anyscale_provider/operators/anyscale.py", line 385, in execute
    self.service_id = self.hook.deploy_service(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tatiana.alchueyr/Code/astro-provider-anyscale/anyscale_provider/hooks/anyscale.py", line 99, in deploy_service
    service_id: str = self.client.service.deploy(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ServiceSDK.deploy() got an unexpected keyword argument 'config'
```

This PR solves the issue by:
- deprecating the argument `config` in the `AnyscaleHook.deploy_service` method
- introducing a new argument `configs`  in the `AnyscaleHook.deploy_service` method
- handling errors generated in earlier versions of the SDK

I observed that after this fix, there is a different issue in the CI, which will be addressed in a separate PR:
```
[2025-11-20 16:34:21,609] {anyscale.py:420} INFO - Execution completed for service AstroService-CICD-test-94-3-11-2-9 with state: SYSTEM_FAILURE
[2025-11-20T16:34:21.609+0000] {anyscale.py:420} INFO - Execution completed for service AstroService-CICD-test-94-3-11-2-9 with state: SYSTEM_FAILURE
INFO     airflow.task.operators.anyscale_provider.operators.anyscale.RolloutAnyscaleService:anyscale.py:420 Execution completed for service AstroService-CICD-test-94-3-11-2-9 with state: SYSTEM_FAILURE
[2025-11-20 16:34:21,610] {anyscale.py:425} ERROR - Anyscale service deployment AstroService-CICD-test-94-3-11-2-9 failed with error: asyncio.run() cannot be called from a running event loop
[2025-11-20T16:34:21.610+0000] {anyscale.py:425} ERROR - Anyscale service deployment AstroService-CICD-test-94-3-11-2-9 failed with error: asyncio.run() cannot be called from a running event loop
ERROR    airflow.task.operators.anyscale_provider.operators.anyscale.RolloutAnyscaleService:anyscale.py:425 Anyscale service deployment AstroService-CICD-test-94-3-11-2-9 failed with error: asyncio.run() cannot be called from a running event loop
[2025-11-20T16:34:21.610+0000] {taskinstance.py:441} INFO - ::group::Post task execution logs
INFO     airflow.models.taskinstance:taskinstance.py:441 ::group::Post task execution logs
[2025-11-20 16:34:21,614] {taskinstance.py:2890} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/runner/.local/share/hatch/env/virtual/astro-provider-anyscale/UDnurkOL/tests.py3.11-2.9/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 465, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/hatch/env/virtual/astro-provider-anyscale/UDnurkOL/tests.py3.11-2.9/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 432, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/hatch/env/virtual/astro-provider-anyscale/UDnurkOL/tests.py3.11-2.9/lib/python3.11/site-packages/airflow/models/baseoperator.py", line 1700, in resume_execution
    return execute_callable(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/astro-provider-anyscale/astro-provider-anyscale/anyscale_provider/operators/anyscale.py", line 426, in execute_complete
    raise AirflowException(error_msg)
airflow.exceptions.AirflowException: Anyscale service deployment AstroService-CICD-test-94-3-11-2-9 failed with error: asyncio.run() cannot be called from a running event loop
```