### PR TITLE
Fix Triggerer's async thread was blocked from being blocked

### DIFF
--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -146,19 +146,19 @@ class AnyscaleHook(BaseHook):  # type: ignore[misc]
 
     def get_service_status(
         self,
-        service_name: str,
+        name: str,
         cloud: str | None = None,
         project: str | None = None,
     ) -> ServiceStatus:
         """
         Fetch the status of a service.
 
-        :param service_name: The name of the service.
+        :param service_name: (Mandatory) The name of the service.
         :param cloud: Optional. The cloud name for the service.
         :param project: Optional. The project name for the service.
         """
-        self.log.debug(f"Fetching service status for Service: {service_name}")
-        return self.client.service.status(name=service_name, cloud=cloud, project=project)
+        self.log.debug(f"Fetching service status for Service: {name}")
+        return self.client.service.status(name=name, cloud=cloud, project=project)
 
     def terminate_job(self, job_id: str, time_delay: int) -> bool:
         """

--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -141,7 +141,7 @@ class AnyscaleHook(BaseHook):  # type: ignore[misc]
 
         :param job_id: The ID of the job.
         """
-        self.log.info(f"Fetching job status for Job ID: {job_id}")
+        self.log.debug(f"Fetching job status for Job ID: {job_id}")
         return self.client.job.status(id=job_id)
 
     def get_service_status(
@@ -157,7 +157,7 @@ class AnyscaleHook(BaseHook):  # type: ignore[misc]
         :param cloud: Optional. The cloud name for the service.
         :param project: Optional. The project name for the service.
         """
-        self.log.info(f"Fetching service status for Service: {service_name}")
+        self.log.debug(f"Fetching service status for Service: {service_name}")
         return self.client.service.status(name=service_name, cloud=cloud, project=project)
 
     def terminate_job(self, job_id: str, time_delay: int) -> bool:

--- a/anyscale_provider/hooks/anyscale.py
+++ b/anyscale_provider/hooks/anyscale.py
@@ -146,19 +146,19 @@ class AnyscaleHook(BaseHook):  # type: ignore[misc]
 
     def get_service_status(
         self,
-        name: str,
+        service_name: str,
         cloud: str | None = None,
         project: str | None = None,
     ) -> ServiceStatus:
         """
         Fetch the status of a service.
 
-        :param service_name: (Mandatory) The name of the service.
+        :param service_name: The name of the service.
         :param cloud: Optional. The cloud name for the service.
         :param project: Optional. The project name for the service.
         """
-        self.log.debug(f"Fetching service status for Service: {name}")
-        return self.client.service.status(name=name, cloud=cloud, project=project)
+        self.log.debug(f"Fetching service status for Service: {service_name}")
+        return self.client.service.status(name=service_name, cloud=cloud, project=project)
 
     def terminate_job(self, job_id: str, time_delay: int) -> bool:
         """

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -401,8 +401,6 @@ class RolloutAnyscaleService(BaseOperator):
                 service_status = self.hook.get_service_status(service_name=self.name)
                 current_state = service_status.state
                 self.log.info(f"Current service state for {self.name} is: {current_state}")
-                if current_state == ServiceState.RUNNING:
-                    self.log.info(f"Service {self.name} is healthy and running.")
                     has_succeeded = True
                     break
                 elif current_state in failure_states:

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -411,7 +411,7 @@ class RolloutAnyscaleService(BaseOperator):
                 time.sleep(self.poll_interval)
             if not has_succeeded:
                 raise AirflowException(
-                    f"Service {self.name} timed out after {self.service_rollout_timeout_seconds} seconds. The service was not complete within the desired service_rollout_timeout_seconds: {self.service_rollout_timeout_seconds}."
+                    f"Service {self.name} was not completed after {self.service_rollout_timeout_seconds} seconds."
                 )
         else:
             service_status = self.hook.get_service_status(name=self.name)

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -398,7 +398,7 @@ class RolloutAnyscaleService(BaseOperator):
         if self.wait_for_completion:
             has_succeeded = False
             for _ in range(int(self.service_rollout_timeout_seconds // self.poll_interval)):
-                service_status = self.hook.get_service_status(name=self.name)
+                service_status = self.hook.get_service_status(service_name=self.name)
                 current_state = str(service_status.state)
                 self.log.info(f"Current service state for {self.name} is: {current_state}")
                 if current_state == ServiceState.RUNNING:

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -399,7 +399,7 @@ class RolloutAnyscaleService(BaseOperator):
             has_succeeded = False
             for _ in range(int(self.service_rollout_timeout_seconds // self.poll_interval)):
                 service_status = self.hook.get_service_status(service_name=self.name)
-                current_state = str(service_status.state)
+                current_state = service_status.state
                 self.log.info(f"Current service state for {self.name} is: {current_state}")
                 if current_state == ServiceState.RUNNING:
                     self.log.info(f"Service {self.name} is healthy and running.")
@@ -413,7 +413,7 @@ class RolloutAnyscaleService(BaseOperator):
                     f"Service {self.name} was not completed after {self.service_rollout_timeout_seconds} seconds."
                 )
         else:
-            service_status = self.hook.get_service_status(name=self.name)
+            service_status = self.hook.get_service_status(service_name=self.name)
             current_state = str(service_status.state)
             self.log.info(f"Current service state for {self.name} is: {current_state}")
             if current_state in failure_states:

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -194,9 +194,7 @@ class SubmitAnyscaleJob(BaseOperator):
                 time.sleep(self.poll_interval)
                 job_status = self.hook.get_job_status(self.job_id)
             if not has_succeeded:
-                raise AirflowException(
-                    f"Job {self.job_id} was not completed after {self.job_timeout_seconds} seconds. 
-                )
+                raise AirflowException(f"Job {self.job_id} was not completed after {self.job_timeout_seconds} seconds.")
         else:
             job_status = self.hook.get_job_status(self.job_id)
             current_state = str(job_status.state)
@@ -401,6 +399,7 @@ class RolloutAnyscaleService(BaseOperator):
                 service_status = self.hook.get_service_status(service_name=self.name)
                 current_state = service_status.state
                 self.log.info(f"Current service state for {self.name} is: {current_state}")
+                if current_state == ServiceState.RUNNING:
                     has_succeeded = True
                     break
                 elif current_state in failure_states:

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -195,7 +195,7 @@ class SubmitAnyscaleJob(BaseOperator):
                 job_status = self.hook.get_job_status(self.job_id)
             if not has_succeeded:
                 raise AirflowException(
-                    f"Job {self.job_id} timed out after {self.job_timeout_seconds} seconds. The job was not complete within the desired job_timeout_seconds: {self.job_timeout_seconds}."
+                    f"Job {self.job_id} was not completed after {self.job_timeout_seconds} seconds. 
                 )
         else:
             job_status = self.hook.get_job_status(self.job_id)

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -187,7 +187,6 @@ class SubmitAnyscaleJob(BaseOperator):
                 current_state = str(job_status.state)
                 self.log.info(f"Current job state for {self.job_id} is: {current_state}")
                 if current_state == JobState.SUCCEEDED:
-                    self.log.info(f"Job {self.job_id} completed successfully.")
                     has_succeeded = True
                     break
                 elif current_state in failure_states:

--- a/anyscale_provider/operators/anyscale.py
+++ b/anyscale_provider/operators/anyscale.py
@@ -291,7 +291,7 @@ class RolloutAnyscaleService(BaseOperator):
         in_place: bool = False,
         canary_percent: int | None = None,
         max_surge_percent: int | None = None,
-        service_rollout_timeout_seconds: float = 600,
+        service_rollout_timeout_seconds: float = 900,
         poll_interval: float = 60,
         wait_for_completion: bool = True,
         **kwargs: Any,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ line-length = 120
 select = ["C901", "I", "F"]
 ignore = ["F541"]
 [tool.ruff.lint.mccabe]
-max-complexity = 8
+max-complexity = 9
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ line-length = 120
 select = ["C901", "I", "F"]
 ignore = ["F541"]
 [tool.ruff.lint.mccabe]
-max-complexity = 7
+max-complexity = 8
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/tests/operators/test_anyscale_operators.py
+++ b/tests/operators/test_anyscale_operators.py
@@ -50,7 +50,6 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
     def test_execute_failure(self, mock_hook):
-        # This test ensures that when a job submission returns an UNKNOWN state, it raises an exception
         mock_hook.submit_job.return_value = "123"
         mock_hook.get_job_status.return_value.state = JobState.UNKNOWN
 
@@ -68,10 +67,8 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=PropertyMock)
     def test_execute_with_no_hook(self, mock_hook_property):
-        # Simulate the hook not being available by raising an AirflowException
         mock_hook_property.side_effect = AirflowException("SDK is not available.")
 
-        # Execute the operator and expect it to raise an AirflowException
         with self.assertRaises(AirflowException) as context:
             self.operator.execute(Context())
 
@@ -102,18 +99,73 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
         mock_hook.submit_job.return_value = "123"
         mock_hook.get_job_status.return_value.state = JobState.SUCCEEDED
 
-        # Execute the operator
         operator.execute(Context(ti=MagicMock()))
 
-        # Verify that JobConfig was called with the extra parameters
         mock_job_config.assert_called_once()
-        call_args = mock_job_config.call_args[1]  # Get keyword arguments
+        call_args = mock_job_config.call_args[1]
 
-        # Check that the extra_job_params were merged into the job_params
         self.assertEqual(call_args["ray_version"], "2.47.1")
         self.assertEqual(call_args["timeout_s"], 42)
         self.assertEqual(call_args["entrypoint"], "test_entrypoint")
         self.assertEqual(call_args["name"], "test_job")
+
+    @patch("anyscale_provider.operators.anyscale.time.sleep")
+    @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
+    def test_execute_job_timeout(self, mock_hook, mock_sleep):
+        operator = SubmitAnyscaleJob(
+            conn_id="test_conn",
+            name="test_job",
+            entrypoint="test_entrypoint",
+            task_id="test_timeout",
+            job_timeout_seconds=120,  # 2 minutes
+            poll_interval=60,  # 1 minute
+        )
+
+        mock_hook.submit_job.return_value = "123"
+        mock_hook.get_job_status.return_value.state = JobState.RUNNING
+
+        with self.assertRaises(AirflowException) as context:
+            operator.execute(Context(ti=MagicMock()))
+
+        self.assertTrue("Job 123 timed out after 120" in str(context.exception))
+        self.assertTrue("job_timeout_seconds: 120" in str(context.exception))
+
+    @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
+    def test_execute_without_wait_for_completion_success(self, mock_hook):
+        operator = SubmitAnyscaleJob(
+            conn_id="test_conn",
+            name="test_job",
+            entrypoint="test_entrypoint",
+            task_id="test_no_wait",
+            wait_for_completion=False,
+        )
+
+        mock_hook.submit_job.return_value = "123"
+        mock_hook.get_job_status.return_value.state = JobState.SUCCEEDED
+
+        result = operator.execute(Context(ti=MagicMock()))
+
+        self.assertEqual(result, "123")
+        mock_hook.submit_job.assert_called_once()
+        mock_hook.get_job_status.assert_called_once_with("123")
+
+    @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
+    def test_execute_without_wait_for_completion_failure(self, mock_hook):
+        operator = SubmitAnyscaleJob(
+            conn_id="test_conn",
+            name="test_job",
+            entrypoint="test_entrypoint",
+            task_id="test_no_wait_fail",
+            wait_for_completion=False,
+        )
+
+        mock_hook.submit_job.return_value = "123"
+        mock_hook.get_job_status.return_value.state = JobState.FAILED
+
+        with self.assertRaises(AirflowException) as context:
+            operator.execute(Context(ti=MagicMock()))
+
+        self.assertTrue("Job 123 failed." in str(context.exception))
 
 
 class TestRolloutAnyscaleService(unittest.TestCase):
@@ -133,20 +185,16 @@ class TestRolloutAnyscaleService(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
     def test_execute_successful(self, mock_hook):
-        # Mock successful service deployment
         mock_hook.deploy_service.return_value = "service123"
         mock_hook.get_service_status.return_value.state = ServiceState.RUNNING
 
         result = self.operator.execute(Context(ti=MagicMock()))
 
-        # Verify deploy_service was called
         mock_hook.deploy_service.assert_called_once()
-        # Verify the service_id was returned
         self.assertEqual(result, "service123")
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
     def test_execute_failed(self, mock_hook):
-        # Mock service deployment that results in a failure state
         mock_hook.deploy_service.return_value = "service123"
         mock_hook.get_service_status.return_value.state = ServiceState.SYSTEM_FAILURE
 
@@ -159,6 +207,71 @@ class TestRolloutAnyscaleService(unittest.TestCase):
     def test_check_anyscale_hook(self, mock_hook_property):
         self.operator.hook.client
         mock_hook_property.assert_called_once()
+
+    @patch("anyscale_provider.operators.anyscale.time.sleep")
+    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
+    def test_execute_service_timeout(self, mock_hook, mock_sleep):
+        # Test that service times out when it doesn't complete within service_rollout_timeout_seconds
+        operator = RolloutAnyscaleService(
+            conn_id="test_conn",
+            name="test_service",
+            applications=[{"name": "app1", "import_path": "module.optional_submodule:app"}],
+            task_id="test_timeout",
+            service_rollout_timeout_seconds=120,  # 2 minutes
+            poll_interval=60,  # 1 minute
+        )
+
+        mock_hook.deploy_service.return_value = "service123"
+        # Service stays in STARTING state and never completes
+        mock_hook.get_service_status.return_value.state = ServiceState.STARTING
+
+        with self.assertRaises(AirflowException) as context:
+            operator.execute(Context(ti=MagicMock()))
+
+        self.assertTrue("Service test_service was not completed after 120" in str(context.exception))
+
+    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
+    def test_execute_without_wait_for_completion_success(self, mock_hook):
+        operator = RolloutAnyscaleService(
+            conn_id="test_conn",
+            name="test_service",
+            applications=[{"name": "app1", "import_path": "module.optional_submodule:app"}],
+            task_id="test_no_wait",
+            wait_for_completion=False,
+        )
+
+        mock_hook.deploy_service.return_value = "service123"
+        mock_hook.get_service_status.return_value.state = ServiceState.RUNNING
+
+        result = operator.execute(Context(ti=MagicMock()))
+
+        self.assertEqual(result, "service123")
+        mock_hook.deploy_service.assert_called_once()
+        mock_hook.get_service_status.assert_called_once_with(service_name="test_service")
+
+    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
+    def test_execute_without_wait_for_completion_failure(self, mock_hook):
+        operator = RolloutAnyscaleService(
+            conn_id="test_conn",
+            name="test_service",
+            applications=[{"name": "app1", "import_path": "module.optional_submodule:app"}],
+            task_id="test_no_wait_fail",
+            wait_for_completion=False,
+        )
+
+        mock_hook.deploy_service.return_value = "service123"
+        mock_hook.get_service_status.return_value.state = ServiceState.SYSTEM_FAILURE
+
+        with self.assertRaises(AirflowException) as context:
+            operator.execute(Context(ti=MagicMock()))
+
+        self.assertTrue("Service test_service failed." in str(context.exception))
+
+    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
+    def test_on_kill(self, mock_hook):
+        # Test that on_kill properly terminates the service
+        self.operator.on_kill()
+        mock_hook.terminate_service.assert_called_once_with("test_service", 5)
 
 
 if __name__ == "__main__":

--- a/tests/operators/test_anyscale_operators.py
+++ b/tests/operators/test_anyscale_operators.py
@@ -127,8 +127,7 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
         with self.assertRaises(AirflowException) as context:
             operator.execute(Context(ti=MagicMock()))
 
-        self.assertTrue("Job 123 timed out after 120" in str(context.exception))
-        self.assertTrue("job_timeout_seconds: 120" in str(context.exception))
+        self.assertTrue("Job 123 was not completed after 120" in str(context.exception))
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
     def test_execute_without_wait_for_completion_success(self, mock_hook):

--- a/tests/operators/test_anyscale_operators.py
+++ b/tests/operators/test_anyscale_operators.py
@@ -49,10 +49,11 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
     def test_execute_failure(self, mock_hook):
+        assert False
         # event = {"state": JobState.FAILED, "job_id": "123", "message": "Job failed with error"}
-        with self.assertRaises(AirflowException) as context:
-            self.operator.execute(Context())
-        self.assertTrue("Job 123 failed with error" in str(context.exception))
+        # with self.assertRaises(AirflowException) as context:
+        #    self.operator.execute(Context())
+        # self.assertTrue("Job 123 failed with error" in str(context.exception))
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=PropertyMock)
     def test_check_anyscale_hook(self, mock_hook_property):
@@ -123,6 +124,7 @@ class TestRolloutAnyscaleService(unittest.TestCase):
             task_id="rollout_service_test",
             cloud="test_cloud",
             project="test_project",
+            do_xcom_push=False,
         )
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
@@ -135,10 +137,11 @@ class TestRolloutAnyscaleService(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
     def test_execute_failed(self, mock_hook):
+        assert False
         # event = {"state": ServiceState.SYSTEM_FAILURE, "service_name": "service123", "message": "Deployment failed"}
-        with self.assertRaises(AirflowException) as cm:
-            self.operator.execute(Context())
-        self.assertIn("Anyscale service deployment service123 failed with error", str(cm.exception))
+        # with self.assertRaises(AirflowException) as cm:
+        #    self.operator.execute(Context())
+        # self.assertIn("Anyscale service deployment service123 failed with error", str(cm.exception))
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook", new_callable=PropertyMock)
     def test_check_anyscale_hook(self, mock_hook_property):

--- a/tests/operators/test_anyscale_operators.py
+++ b/tests/operators/test_anyscale_operators.py
@@ -1,13 +1,11 @@
 import unittest
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.exceptions import AirflowException
 from airflow.utils.context import Context
 from anyscale.job.models import JobState
-from anyscale.service.models import ServiceState
 
 from anyscale_provider.operators.anyscale import RolloutAnyscaleService, SubmitAnyscaleJob
-from anyscale_provider.triggers.anyscale import AnyscaleJobTrigger, AnyscaleServiceTrigger
 
 
 class TestSubmitAnyscaleJob(unittest.TestCase):
@@ -20,6 +18,7 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
             working_dir="/test/dir",
             entrypoint="test_entrypoint",
             task_id="submit_job_test",
+            do_xcom_push=False,
         )
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=MagicMock)
@@ -49,15 +48,10 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
         mock_hook.terminate_job.assert_called_once_with("123", 5)
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
-    def test_execute_complete(self, mock_hook):
-        event = {"state": JobState.SUCCEEDED, "job_id": "123", "message": "Job completed successfully"}
-        self.assertEqual(self.operator.execute_complete(Context(), event), "123")
-
-    @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook")
-    def test_execute_complete_failure(self, mock_hook):
-        event = {"state": JobState.FAILED, "job_id": "123", "message": "Job failed with error"}
+    def test_execute_failure(self, mock_hook):
+        # event = {"state": JobState.FAILED, "job_id": "123", "message": "Job failed with error"}
         with self.assertRaises(AirflowException) as context:
-            self.operator.execute_complete(Context(), event)
+            self.operator.execute(Context())
         self.assertTrue("Job 123 failed with error" in str(context.exception))
 
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=PropertyMock)
@@ -87,25 +81,6 @@ class TestSubmitAnyscaleJob(unittest.TestCase):
         with self.assertRaises(AirflowException) as context:
             self.operator.execute(Context(ti=MagicMock()))
         self.assertTrue("Job 123 failed." in str(context.exception))
-
-    @patch("airflow.models.BaseOperator.defer")
-    @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=MagicMock)
-    def test_defer_job_polling(self, mock_hook, mock_defer):
-        # Mock the submit_job method to return a job ID
-        mock_hook.submit_job.return_value = "123"
-        # Mock the get_job_status method to return a starting state
-        mock_hook.get_job_status.return_value.state = JobState.STARTING
-
-        # Call the execute method which internally calls process_job_status and defer_job_polling
-        self.operator.execute(Context(ti=MagicMock()))
-
-        # Check that the defer method was called with the correct arguments
-        mock_defer.assert_called_once()
-        args, kwargs = mock_defer.call_args
-        self.assertIsInstance(kwargs["trigger"], AnyscaleJobTrigger)
-        self.assertEqual(kwargs["trigger"].job_id, "123")
-        self.assertEqual(kwargs["trigger"].conn_id, "test_conn")
-        self.assertEqual(kwargs["method_name"], "execute_complete")
 
     @patch("anyscale_provider.operators.anyscale.JobConfig")
     @patch("anyscale_provider.operators.anyscale.SubmitAnyscaleJob.hook", new_callable=MagicMock)
@@ -152,56 +127,18 @@ class TestRolloutAnyscaleService(unittest.TestCase):
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
     def test_execute_successful(self, mock_hook):
-        mock_hook.return_value.deploy_service.return_value = "service123"
-        with self.assertRaises(TaskDeferred):
-            self.operator.execute(Context(ti=MagicMock()))
+        assert False
 
-    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.defer")
-    @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook", new_callable=MagicMock)
-    def test_defer_trigger_called(self, mock_hook, mock_defer):
-        mock_hook.return_value.deploy_service.return_value = "service123"
-
-        self.operator.execute(Context(ti=MagicMock()))
-
-        # Extract the actual call arguments
-        actual_call_args = mock_defer.call_args
-
-        # Define the expected trigger and method_name
-        expected_trigger = AnyscaleServiceTrigger(
-            conn_id="test_conn",
-            service_name="test_service",
-            expected_state=ServiceState.RUNNING,
-            canary_percent=None,
-            cloud="test_cloud",
-            project="test_project",
-            poll_interval=60,
-        )
-
-        expected_method_name = "execute_complete"
-
-        # Perform individual assertions
-        actual_trigger = actual_call_args.kwargs["trigger"]
-        actual_method_name = actual_call_args.kwargs["method_name"]
-
-        self.assertEqual(actual_trigger.conn_id, expected_trigger.conn_id)
-        self.assertEqual(actual_trigger.service_name, expected_trigger.service_name)
-        self.assertEqual(actual_trigger.expected_state, expected_trigger.expected_state)
-        self.assertEqual(actual_trigger.cloud, expected_trigger.cloud)
-        self.assertEqual(actual_trigger.project, expected_trigger.project)
-        self.assertEqual(actual_trigger.poll_interval, expected_trigger.poll_interval)
-        self.assertEqual(actual_method_name, expected_method_name)
+    #    mock_hook.return_value.deploy_service.return_value = "service123"
+    #    with self.assertRaises(TaskDeferred):
+    #        self.operator.execute(Context(ti=MagicMock()))
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook")
-    def test_execute_complete_failed(self, mock_hook):
-        event = {"state": ServiceState.SYSTEM_FAILURE, "service_name": "service123", "message": "Deployment failed"}
+    def test_execute_failed(self, mock_hook):
+        # event = {"state": ServiceState.SYSTEM_FAILURE, "service_name": "service123", "message": "Deployment failed"}
         with self.assertRaises(AirflowException) as cm:
-            self.operator.execute_complete(Context(), event)
+            self.operator.execute(Context())
         self.assertIn("Anyscale service deployment service123 failed with error", str(cm.exception))
-
-    def test_execute_complete_success(self):
-        event = {"state": ServiceState.RUNNING, "service_name": "service123", "message": "Deployment succeeded"}
-        self.operator.execute_complete(Context(), event)
-        self.assertEqual(self.operator.name, "test_service")
 
     @patch("anyscale_provider.operators.anyscale.RolloutAnyscaleService.hook", new_callable=PropertyMock)
     def test_check_anyscale_hook(self, mock_hook_property):


### PR DESCRIPTION
Change operators to not use the Airflow Triggerer to poll the job status. This mitigates user reports of production issues when running the provider, since the provider attempts to make synchronous API calls to Anyscale in a component that should use asynchronous calls to external services.

The Anyscale Airflow provider has a conceptual issue that was introduced over a year ago (https://github.com/astronomer/astro-provider-anyscale/pull/27).

While it attempts to run checks on the service status asynchronously, the Triggerer still makes synchronous calls to the Anyscale service. This does not play well with the Airflow Triggerer, as you can see from the Airflow logs:
```
Triggerer's async thread was blocked for 2886.21 seconds, likely due to a badly written trigger.
```

When the triggerer is running blocking operations, it stops responding to health checks - leading to production deployments becoming unhealthy.

The issue was first raised via Astronomer Zendesk, and brought to our team's attention via the Slack #airflow channel:
https://astronomer.zendesk.com/agent/tickets/85680
https://astronomer.slack.com/archives/CGQSYG25V/p1764095902756259

This issue was discussed with Anyscale via the Slack channel #astro_anyscale, in the Astronomer namespace:
https://astronomer.slack.com/archives/C01N6R8LJG7/p1764164978211799

Example of code leading to this problem:
https://github.com/astronomer/astro-provider-anyscale/blob/5b29467d93ee613f7e66802907bf424d9550d850/anyscale_provider/triggers/anyscale.py#L71

Until the Anyscale Python SDK supports asynchronous calls (the latest version - 0.26.75 - currenlty does not support), there would be within Astronomer's control, there are two solutions under our control:
1. Make the code synchronous (quick)
2. Consider replacing the Anyscale Python SDK to use the non-public Anyscale HTTP API and performing asynchronous calls with an async HTTP client. The challenge is that there seems to be no public documentation for this HTTP call (the intended entry points appear to be the SDK or the Anyscale CLI).

Since the current implementation is causing customer issues, this PR implements the fastest solution (1).

The fix was validated by running:
```
AIRFLOW_HOME=`pwd` airflow dags test sample_anyscale_job_workflow
AIRFLOW_HOME=`pwd` airflow dags test sample_anyscale_service_workflow
```

And also by running via the Airflow UI.

Example of successful runs:
<img width="1204" height="506" alt="Screenshot 2025-11-27 at 12 20 02" src="https://github.com/user-attachments/assets/2ec76b0d-5c99-43d5-986c-35e480bca03c" />
<img width="1203" height="411" alt="Screenshot 2025-11-27 at 12 24 06" src="https://github.com/user-attachments/assets/72ae5474-b548-4b4a-a3a7-f1086f5e5a4e" />

Follow-up tickets:
- https://github.com/astronomer/astro-provider-anyscale/issues/100
- https://github.com/astronomer/astro-provider-anyscale/issues/101

Closes: https://github.com/astronomer/oss-integrations-private/issues/283