### PR TITLE
Make integration-test Anyscale compute config/image overridable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,10 @@ jobs:
           ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
         env:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          # Set these as repo variables to point integration tests at a compute config / image
+          # that exist on the Anyscale account; if unset, the example DAGs fall back to defaults.
+          ASTRO_ANYSCALE_COMPUTE_CONFIG: ${{ vars.ASTRO_ANYSCALE_COMPUTE_CONFIG }}
+          ASTRO_ANYSCALE_IMAGE_URI: ${{ vars.ASTRO_ANYSCALE_IMAGE_URI }}
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v6
         with:

--- a/example_dags/anyscale_job.py
+++ b/example_dags/anyscale_job.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -5,6 +6,13 @@ from airflow import DAG
 from anyscale.job.models import JobQueueConfig, JobQueueExecutionMode, JobQueueSpec
 
 from anyscale_provider.operators.anyscale import SubmitAnyscaleJob
+
+# Integration tests run this example DAG against the Anyscale account tied to
+# ANYSCALE_CLI_TOKEN, so the compute config and image below must exist on that
+# account. Override them without editing this file via env vars (e.g. CI repo
+# variables): ASTRO_ANYSCALE_COMPUTE_CONFIG / ASTRO_ANYSCALE_IMAGE_URI.
+ANYSCALE_COMPUTE_CONFIG = os.getenv("ASTRO_ANYSCALE_COMPUTE_CONFIG") or "airflow-integration-testing:1"
+ANYSCALE_IMAGE_URI = os.getenv("ASTRO_ANYSCALE_IMAGE_URI") or "anyscale/image/airflow-integration-testing:1"
 
 default_args = {
     "owner": "airflow",
@@ -34,8 +42,8 @@ submit_anyscale_job = SubmitAnyscaleJob(
     task_id="submit_anyscale_job",
     conn_id=ANYSCALE_CONN_ID,
     name="AstroJobBasic",
-    image_uri="anyscale/image/airflow-integration-testing:1",
-    compute_config="airflow-integration-testing:1",
+    image_uri=ANYSCALE_IMAGE_URI,
+    compute_config=ANYSCALE_COMPUTE_CONFIG,
     working_dir=str(FOLDER_PATH),
     entrypoint="python ray-job.py",
     requirements=["requests", "pandas", "numpy", "torch"],
@@ -51,8 +59,8 @@ submit_anyscale_job_with_new_job_queue = SubmitAnyscaleJob(
     task_id="submit_anyscale_job_with_new_job_queue",
     conn_id=ANYSCALE_CONN_ID,
     name="AstroJobWithJobQueue",
-    image_uri="anyscale/image/airflow-integration-testing:1",
-    compute_config="airflow-integration-testing:1",
+    image_uri=ANYSCALE_IMAGE_URI,
+    compute_config=ANYSCALE_COMPUTE_CONFIG,
     working_dir=str(FOLDER_PATH),
     entrypoint="python ray-job.py",
     max_retries=1,
@@ -74,8 +82,8 @@ submit_anyscale_job_with_existing_job_queue = SubmitAnyscaleJob(
     task_id="submit_anyscale_job_with_existing_job_queue",
     conn_id=ANYSCALE_CONN_ID,
     name="AstroJobWithExistingJobQueue1",
-    image_uri="anyscale/image/airflow-integration-testing:1",
-    compute_config="airflow-integration-testing:1",
+    image_uri=ANYSCALE_IMAGE_URI,
+    compute_config=ANYSCALE_COMPUTE_CONFIG,
     working_dir=str(FOLDER_PATH),
     entrypoint="python ray-job.py",
     max_retries=1,
@@ -98,8 +106,8 @@ submit_another_anyscale_job_with_existing_job_queue = SubmitAnyscaleJob(
     task_id="submit_another_anyscale_job_with_existing_job_queue",
     conn_id=ANYSCALE_CONN_ID,
     name="AstroJobWithExistingJobQueue2",
-    image_uri="anyscale/image/airflow-integration-testing:1",
-    compute_config="airflow-integration-testing:1",
+    image_uri=ANYSCALE_IMAGE_URI,
+    compute_config=ANYSCALE_COMPUTE_CONFIG,
     working_dir=str(FOLDER_PATH),
     entrypoint="python ray-job.py",
     max_retries=1,

--- a/example_dags/anyscale_service.py
+++ b/example_dags/anyscale_service.py
@@ -22,6 +22,10 @@ default_args = {
 ANYSCALE_CONN_ID = "anyscale_conn"
 service_id = os.getenv("ASTRO_ANYSCALE_PROVIDER_SERVICE_ID", {uuid.uuid4()})
 SERVICE_NAME = f"AstroService-CICD-{service_id}"
+# Must exist on the Anyscale account tied to ANYSCALE_CLI_TOKEN; override via env vars
+# ASTRO_ANYSCALE_COMPUTE_CONFIG / ASTRO_ANYSCALE_IMAGE_URI (e.g. CI repo variables).
+ANYSCALE_COMPUTE_CONFIG = os.getenv("ASTRO_ANYSCALE_COMPUTE_CONFIG") or "airflow-integration-testing:1"
+ANYSCALE_IMAGE_URI = os.getenv("ASTRO_ANYSCALE_IMAGE_URI") or "anyscale/image/airflow-integration-testing:1"
 
 dag = DAG(
     "sample_anyscale_service_workflow",
@@ -35,8 +39,8 @@ deploy_anyscale_service = RolloutAnyscaleService(
     task_id="rollout_anyscale_service",
     conn_id=ANYSCALE_CONN_ID,
     name=SERVICE_NAME,
-    image_uri="anyscale/image/airflow-integration-testing:1",
-    compute_config="airflow-integration-testing:1",
+    image_uri=ANYSCALE_IMAGE_URI,
+    compute_config=ANYSCALE_COMPUTE_CONFIG,
     working_dir="https://github.com/anyscale/docs_examples/archive/refs/heads/main.zip",
     applications=[{"import_path": "sentiment_analysis.app:model"}],
     requirements=["transformers", "requests", "pandas", "numpy", "torch"],


### PR DESCRIPTION
## Summary

Integration tests submit real Anyscale jobs/services using the example DAGs, which **hardcode** `compute_config` / `image_uri` = `airflow-integration-testing:1`. That compute config no longer exists on the Anyscale test account, so every integration run fails at job submission (verified in the failing logs):

```
ValueError: The compute config 'airflow-integration-testing:1' does not exist.
```
(The token is valid — `ANYSCALE_CLI_TOKEN` is set and the SDK authenticates; only the named fixture is missing.)

This makes the fixtures **overridable via env vars**, defaulting to the canonical names, mirroring the existing `ASTRO_ANYSCALE_PROVIDER_SERVICE_ID` pattern:

- `example_dags/anyscale_job.py`, `example_dags/anyscale_service.py`: `compute_config` / `image_uri` now read `ASTRO_ANYSCALE_COMPUTE_CONFIG` / `ASTRO_ANYSCALE_IMAGE_URI` (falling back to `airflow-integration-testing:1` when unset/empty).
- `.github/workflows/test.yml`: integration job passes those through from repo **variables**, so CI can be pointed at existing fixtures without code changes.

## ⚠️ Still required to make integration green (account-side, not code)
A valid compute config **and** image must exist on the Anyscale account tied to `ANYSCALE_CLI_TOKEN`. Either:
- **Recreate** the fixtures: `anyscale compute-config create -n airflow-integration-testing -f <spec>.yaml` and build/push the `airflow-integration-testing` image; or
- Point CI at existing ones by setting repo variables `ASTRO_ANYSCALE_COMPUTE_CONFIG` / `ASTRO_ANYSCALE_IMAGE_URI`.

This needs Anyscale account access, so it can't be done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
