### PR TITLE
Use PyPI trusted publishing instead of API token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@v7
@@ -38,6 +41,3 @@ jobs:
 
       - name: Push build artifacts to PyPi
         uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Switches the release workflow's `publish` job to PyPI trusted publishing (OIDC)