### PR TITLE
ci: harden integration workflow against template injection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   Authorize:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
@@ -29,6 +32,7 @@ jobs:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
@@ -47,14 +51,17 @@ jobs:
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test Anyscale against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
-        run: |
-          ID="${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.airflow-version }}"
-          # Service names must be no longer than 57 characters and can only contain alphanumeric characters, dashes, and underscores
-          ID_CLEANED=$(echo $ID | tr '.' '-' | tr '/' '-')  # Replace dots and forward slashes with hyphens so it is a valid Service name
-          echo $ID_CLEANED
-          ASTRO_ANYSCALE_PROVIDER_SERVICE_ID=$ID_CLEANED hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
         env:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          GH_WORKFLOW: ${{ github.workflow }}
+          PR_REF: ${{ github.event.pull_request.number || github.ref }}
+          AIRFLOW_VERSION: ${{ matrix.airflow-version }}
+        run: |
+          ID="${GH_WORKFLOW}-${PR_REF}-${AIRFLOW_VERSION}"
+          # Service names must be no longer than 57 characters and can only contain alphanumeric characters, dashes, and underscores
+          ID_CLEANED=$(echo "$ID" | tr '.' '-' | tr '/' '-')  # Replace dots and forward slashes with hyphens so it is a valid Service name
+          echo "$ID_CLEANED"
+          ASTRO_ANYSCALE_PROVIDER_SERVICE_ID="$ID_CLEANED" hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-integration
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5975040f7f7d40edaff8d784b576fd65ae95c073  # v5.5.5


### PR DESCRIPTION
Independent of #122 (both branch from `main`; they touch non-overlapping lines and merge cleanly in either order).

## What

Hardens the `pull_request_target` integration job in `test.yml`:

- **Template-injection fix.** `${{ github.workflow }}` and `${{ github.event.pull_request.number || github.ref }}` were interpolated directly into the integration job's `run:` shell block. Moved into `env:` and referenced as quoted shell variables (`"$GH_WORKFLOW"`, `"$PR_REF"`, `"$AIRFLOW_VERSION"`). No behavior change.
- **`permissions: contents: read`** at workflow level — drops the default broad `GITHUB_TOKEN` scope.
- **`persist-credentials: false`** on the integration checkout — keeps git credentials out of the workspace.

## Why

The integration job runs checked-out PR code with `ANYSCALE_CLI_TOKEN` available. Interpolating context values into a shell block is a code-injection path into that privileged runner; the `env:` indirection closes it.

## On the remaining zizmor findings

- `dangerous-triggers` on `pull_request_target`: **accepted** — fork PRs route through the `external` environment's `required_reviewers` approval, so a maintainer must sign off before untrusted code reaches the secret. zizmor flags the trigger categorically.
- `artipacked` on the Static-Check / Run-Unit-Tests / Code-Coverage checkouts: addressed by #122, which moves those jobs to a separate secret-free `pull_request` workflow. This PR only hardens the integration checkout.

After this PR **and** #122 land, `test.yml` is clean except the accepted `dangerous-triggers` warning.