### PR TITLE
ci: scope permissions and credentials in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build wheels and source distribution
@@ -11,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install build dependencies
         run: python -m pip install --upgrade build


### PR DESCRIPTION
Closes the three real zizmor findings in `release.yml` (the PyPI deploy workflow), in one pass.

## What

- **`permissions: contents: read`** at workflow level. The `build` job previously inherited the default broad `GITHUB_TOKEN`; it only needs read to check out and build. The `publish` job is unaffected — it keeps its own `permissions: id-token: write` override for trusted publishing.
- **`persist-credentials: false`** on the `build` checkout, so git credentials aren't left in the workspace.

## Findings addressed

| zizmor | Location | 
|--------|----------|
| `excessive-permissions` (workflow) | `release.yml:1` |
| `excessive-permissions` (`build` job) | `release.yml:8` |
| `artipacked` (`build` checkout) | `release.yml:13` |

## Verification

`zizmor --offline` (default persona) on `release.yml`: **No findings**. The two remaining items are pedantic-persona only (`undocumented-permissions`, `concurrency-limits`) and intentionally out of scope.

No behavior change: the build still produces the same artifact, and trusted publishing is untouched.