### PR TITLE
Bump anyscale SDK minimum to >=0.26.104 (closes #130)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10, <3.13"
 dependencies = [
     "apache-airflow>=2.7",
     "pyyaml",
-    "anyscale>=0.24.54",
+    "anyscale>=0.26.104",
 ]
 
 [project.urls]


### PR DESCRIPTION
Raise the `anyscale` dependency floor from >=0.24.54 to >=0.26.104 to pick up the latest SDK fixes and stay current with its API - This fixes issue #130