### PR TITLE
initial commit for changing ownership - closes #134

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To disable usage stats collection, set the configuration `anyscale.telemetry_ena
 _________
 
 We follow [Semantic Versioning](https://semver.org/) for releases.
-Check [CHANGELOG.rst](https://github.com/astronomer/astro-provider-anyscale/blob/main/docs/CHANGELOG.rst)
+Check [CHANGELOG.rst](https://github.com/anyscale/astro-provider-anyscale/blob/main/docs/CHANGELOG.rst)
 for the latest changes.
 
 
@@ -204,4 +204,4 @@ ______________________
 
 All contributions, bug reports, bug fixes, documentation improvements, enhancements are welcome.
 
-A detailed overview an how to contribute can be found in the [Contributing Guide](https://github.com/astronomer/astro-provider-anyscale/blob/main/docs/CONTRIBUTING.rst)
+A detailed overview an how to contribute can be found in the [Contributing Guide](https://github.com/anyscale/astro-provider-anyscale/blob/main/docs/CONTRIBUTING.rst)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "astro-provider-anyscale"
-copyright = "2024, Astronomer"
-author = "Astronomer"
-release = "1.0.1"
+copyright = "2026, Anyscale"
+author = "Anyscale"
+release = "1.3.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "astro-provider-anyscale"
-authors = [{ name = "Astronomer", email = "humans@astronomer.io" }]
+authors = [{ name = "Anyscale", email = "abhi@anyscale.com" }]
 license = { text = "Apache License 2.0" }
-description = "An Apache Airflow provider package built by Astronomer to integrate with Anyscale."
+description = "An Apache Airflow provider package to integrate with Anyscale SDK."
 classifiers = [
     "Framework :: Apache Airflow",
     "Framework :: Apache Airflow :: Provider",
@@ -28,8 +28,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://astronomer.io"
-Source = "https://github.com/astronomer/astro-provider-anyscale/"
+Homepage = "https://anyscale.com"
+Source = "https://github.com/anyscale/astro-provider-anyscale/"
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
## Changes made

- [x] Update authors, description, and URLs in `pyproject.toml`
- [x] Copyright, author, and release version (corrected) in `docs/conf.py`, and repo links in `README.md`

## What's missing in this PR

- [ ] Currently [CODEOWNERS](https://github.com/anyscale/astro-provider-anyscale/blob/089f0888cb4f247ab45b66a3fb3bde7cb209f048/CODEOWNERS) says: `@astronomer/oss-integration`
- [ ] At the moment, the [pyproject.toml](https://github.com/anyscale/astro-provider-anyscale/blob/089f0888cb4f247ab45b66a3fb3bde7cb209f048/pyproject.toml) uses my email address <abhi@anyscale.com>; We should swap the author email for a team alias
- [ ] Bump the release version to 1.4.0
- [ ] Release new version to PyPi